### PR TITLE
Added pico tmx to installs

### DIFF
--- a/install_mirte.sh
+++ b/install_mirte.sh
@@ -28,6 +28,8 @@ sudo bash -c "echo 'extra-index-url=https://www.piwheels.org/simple' >> /etc/pip
 # Install telemetrix
 cd $MIRTE_SRC_DIR/mirte-telemetrix-aio
 pip3 install .
+cd $MIRTE_SRC_DIR/mirte-tmx-pico-aio
+pip3 install .
 
 # Install Telemtrix4Arduino project
 # TODO: building STM sometimes fails (and/or hangs)

--- a/repos.yaml
+++ b/repos.yaml
@@ -15,6 +15,10 @@ repositories:
     type: git
     url: https://github.com/mirte-robot/telemetrix-aio.git
     version: master
+  mirte-tmx-pico-aio:
+    type: git
+    url: https://github.com/mirte-robot/tmx-pico-aio.git
+    version: master
   mirte-ros-packages:
     type: git
     url: https://github.com/mirte-robot/mirte-ros-packages.git


### PR DESCRIPTION
The install for our forked tmx-pico-aio repo was missing.