### PR TITLE
Replace al 0s in Mirte hostname with As at generate time

### DIFF
--- a/network_setup.sh
+++ b/network_setup.sh
@@ -111,7 +111,8 @@ $MIRTE_SRC_DIR/mirte-install-scripts/usb_ethernet.sh
 if [ ! -f /etc/ssid ] || [[ $(cat /etc/hostname) == "Mirte-XXXXXX" ]]; then
 	UNIQUE_ID=$(openssl rand -hex 3)
 	MIRTE_SSID=Mirte-$(echo ${UNIQUE_ID^^})
-	MIRTE_SSID=${MIRTE_SSID//0/A} # replace al 0s with As
+	# replace al 0s with As to make it clearer for users when looking at the leds, as 0 is difficult to recognize
+	MIRTE_SSID=${MIRTE_SSID//0/A}
 	sudo bash -c 'echo '$MIRTE_SSID' > /etc/hostname'
 	sudo ln -s /etc/hostname /etc/ssid
 	# And add them to the hosts file

--- a/network_setup.sh
+++ b/network_setup.sh
@@ -109,7 +109,7 @@ $MIRTE_SRC_DIR/mirte-install-scripts/usb_ethernet.sh
 # be generated on first boot (so not when generating
 # the image in network_setup.sh)
 if [ ! -f /etc/ssid ] || [[ $(cat /etc/hostname) == "Mirte-XXXXXX" ]]; then
-	UNIQUE_ID=$(tr -cd "1-9A-F" < /dev/urandom | head -c 6)
+	UNIQUE_ID=$(tr -cd "1-9A-F" </dev/urandom | head -c 6)
 	MIRTE_SSID=Mirte-$(echo ${UNIQUE_ID^^})
 	sudo bash -c 'echo '$MIRTE_SSID' > /etc/hostname'
 	sudo ln -s /etc/hostname /etc/ssid

--- a/network_setup.sh
+++ b/network_setup.sh
@@ -109,10 +109,8 @@ $MIRTE_SRC_DIR/mirte-install-scripts/usb_ethernet.sh
 # be generated on first boot (so not when generating
 # the image in network_setup.sh)
 if [ ! -f /etc/ssid ] || [[ $(cat /etc/hostname) == "Mirte-XXXXXX" ]]; then
-	UNIQUE_ID=$(openssl rand -hex 3)
+	UNIQUE_ID=$(tr -cd "1-9A-F" < /dev/urandom | head -c 6)
 	MIRTE_SSID=Mirte-$(echo ${UNIQUE_ID^^})
-	# replace al 0s with As to make it clearer for users when looking at the leds, as 0 is difficult to recognize
-	MIRTE_SSID=${MIRTE_SSID//0/A}
 	sudo bash -c 'echo '$MIRTE_SSID' > /etc/hostname'
 	sudo ln -s /etc/hostname /etc/ssid
 	# And add them to the hosts file

--- a/network_setup.sh
+++ b/network_setup.sh
@@ -111,6 +111,7 @@ $MIRTE_SRC_DIR/mirte-install-scripts/usb_ethernet.sh
 if [ ! -f /etc/ssid ] || [[ $(cat /etc/hostname) == "Mirte-XXXXXX" ]]; then
 	UNIQUE_ID=$(openssl rand -hex 3)
 	MIRTE_SSID=Mirte-$(echo ${UNIQUE_ID^^})
+	MIRTE_SSID=${MIRTE_SSID//0/A} # replace al 0s with As
 	sudo bash -c 'echo '$MIRTE_SSID' > /etc/hostname'
 	sudo ln -s /etc/hostname /etc/ssid
 	# And add them to the hosts file


### PR DESCRIPTION
Fix #28 by replacing all 0s with As when generating a new hostname