### PR TITLE
Add picotool

### DIFF
--- a/install_arduino.sh
+++ b/install_arduino.sh
@@ -59,7 +59,6 @@ echo -e "mirte_mirte\nmirte_mirte" | sudo passwd root
 sudo ln -s $MIRTE_SRC_DIR/mirte-install-scripts/run-avrdude /usr/bin
 sudo bash -c 'echo "mirte ALL = (root) NOPASSWD: /usr/local/bin/arduino-cli" >> /etc/sudoers'
 
-
 # Install picotool for the Raspberry Pi Pico
 sudo apt install build-essential pkg-config libusb-1.0-0-dev cmake -y
 cd /tmp/ || exit 1
@@ -78,9 +77,10 @@ cd /tmp || exit 1
 rm -rf pico-sdk
 rm -rf picotool
 
-#  Download latest uf2 release
-curl -s https://api.github.com/repos/mirte-robot/telemetrix4rpipico/releases/latest \
-| grep ".*uf2" \
-| cut -d : -f 2,3 \
-| tr -d \" \
-| wget -qi -
+#  Download latest uf2 release, resulting in Telemetrix4RpiPico.uf2
+cd $MIRTE_SRC_DIR/mirte-install-scripts || exit 1
+curl -s https://api.github.com/repos/mirte-robot/telemetrix4rpipico/releases/latest |
+	grep ".*uf2" |
+	cut -d : -f 2,3 |
+	tr -d \" |
+	wget -qi -

--- a/install_arduino.sh
+++ b/install_arduino.sh
@@ -63,6 +63,7 @@ sudo bash -c 'echo "mirte ALL = (root) NOPASSWD: /usr/local/bin/arduino-cli" >> 
 sudo apt install build-essential pkg-config libusb-1.0-0-dev cmake -y
 cd /tmp/ || exit 1
 git clone https://github.com/raspberrypi/pico-sdk.git # somehow needed for picotool
+export PICO_SDK_PATH=/tmp/pico-sdk
 git clone https://github.com/raspberrypi/picotool.git
 cd picotool || exit 1
 sudo cp udev/99-picotool.rules /etc/udev/rules.d/

--- a/install_arduino.sh
+++ b/install_arduino.sh
@@ -81,7 +81,7 @@ rm -rf picotool
 #  Download latest uf2 release, resulting in Telemetrix4RpiPico.uf2
 cd $MIRTE_SRC_DIR/mirte-install-scripts || exit 1
 curl -s https://api.github.com/repos/mirte-robot/telemetrix4rpipico/releases/latest |
-	grep ".*uf2" |
+	grep ".*/Telemetrix4RpiPico.uf2" |
 	cut -d : -f 2,3 |
 	tr -d \" |
 	wget -qi -

--- a/install_arduino.sh
+++ b/install_arduino.sh
@@ -58,3 +58,29 @@ echo -e "mirte_mirte\nmirte_mirte" | sudo passwd root
 # Enable tuploading from remote IDE
 sudo ln -s $MIRTE_SRC_DIR/mirte-install-scripts/run-avrdude /usr/bin
 sudo bash -c 'echo "mirte ALL = (root) NOPASSWD: /usr/local/bin/arduino-cli" >> /etc/sudoers'
+
+
+# Install picotool for the Raspberry Pi Pico
+sudo apt install build-essential pkg-config libusb-1.0-0-dev cmake -y
+cd /tmp/ || exit 1
+git clone https://github.com/raspberrypi/pico-sdk.git # somehow needed for picotool
+git clone https://github.com/raspberrypi/picotool.git
+cd picotool || exit 1
+sudo cp udev/99-picotool.rules /etc/udev/rules.d/
+
+mkdir build
+cd build || exit 1
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j
+sudo make install
+
+cd /tmp || exit 1
+rm -rf pico-sdk
+rm -rf picotool
+
+#  Download latest uf2 release
+curl -s https://api.github.com/repos/mirte-robot/telemetrix4rpipico/releases/latest \
+| grep ".*uf2" \
+| cut -d : -f 2,3 \
+| tr -d \" \
+| wget -qi -

--- a/run_arduino.sh
+++ b/run_arduino.sh
@@ -40,8 +40,23 @@ if test "$1" == "upload_uno"; then
 	arduino-cli -v upload -p /dev/ttyACM0 --fqbn arduino:avr:uno /home/mirte/arduino_project/$2
 fi
 
+if test "$1" == "upload_pico"; then
+	MIRTE_SRC_DIR=/usr/local/src/mirte
+	sudo picotool load -f $MIRTE_SRC_DIR/mirte-install-scripts/Telemetrix4RpiPico.uf2
+	if $? -ne 0; then
+		echo "Failed to upload to Pico"
+		echo "Please check the connection and try again"
+		echo "Or unplug the Pico, press the BOOTSEL button and plug it in again"
+		exit 1
+	fi
+	sudo picotool reboot
+fi
+
 # Start ROS again
 if test "$1" == "upload" && test "$2" == "Telemetrix4Arduino" && [[ $ROS_RUNNING == "1" ]]; then
 	sudo service mirte-ros start
 	echo "STARTING ROS"
+else
+	echo "NOT STARTING ROS"
+	echo "Start it yourself with 'sudo service mirte-ros start'"
 fi

--- a/run_arduino.sh
+++ b/run_arduino.sh
@@ -7,9 +7,11 @@
 ROS_RUNNING=$(ps aux | grep -c "[r]osmaster")
 
 # Stop ROS when uploading new code
-if test "$1" == "upload" && [[ $ROS_RUNNING == "1" ]]; then
+STOPPED_ROS=false
+if [[ $1 == upload* ]] && [[ $ROS_RUNNING == "1" ]]; then # test for any upload... command
 	echo "STOPPING ROS"
 	sudo service mirte-ros stop || /bin/true
+	STOPPED_ROS=true
 fi
 
 # Different build scripts
@@ -42,18 +44,20 @@ fi
 
 if test "$1" == "upload_pico"; then
 	MIRTE_SRC_DIR=/usr/local/src/mirte
+	# This will always upload telemetrix4rpipico.uf2, so no need to pass a file
 	sudo picotool load -f $MIRTE_SRC_DIR/mirte-install-scripts/Telemetrix4RpiPico.uf2
-	if $? -ne 0; then
+	retVal=$?
+	if [ $retVal -ne 0 ]; then
 		echo "Failed to upload to Pico"
 		echo "Please check the connection and try again"
 		echo "Or unplug the Pico, press the BOOTSEL button and plug it in again"
 		exit 1
 	fi
-	sudo picotool reboot
+	sudo picotool reboot # just to make sure, sometimes it does not reboot automatically
 fi
 
 # Start ROS again
-if test "$1" == "upload" && test "$2" == "Telemetrix4Arduino" && [[ $ROS_RUNNING == "1" ]]; then
+if $STOPPED_ROS; then
 	sudo service mirte-ros start
 	echo "STARTING ROS"
 else


### PR DESCRIPTION
Adds picotool by building and installing it

Adds some better checks to start & restart mirte-ros service

Downloads the latest release uf2 from /mirte-robot/telemetrix4rpipico

